### PR TITLE
Agrego Grunt Task para soporte de postcss

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,7 +9,7 @@ module.exports = function (grunt) {
         watch: {
             sass: {
                 files: ['sass/**/*.{scss,sass}','sass/partials/**/*.{scss,sass}'],
-                tasks: ['sass:dist']
+                tasks: ['sass:dist', 'postcss']
             },
             js: {
                 files: ['js/**/*.js'],
@@ -35,6 +35,18 @@ module.exports = function (grunt) {
                 files: {
                     'css/styles.css': 'sass/styles.scss'
                 }
+            }
+        },
+
+        postcss: {
+            options: {
+              map: true,
+              processors: [
+                require('autoprefixer')({browsers: 'last 3 versions'})
+              ]
+            },
+            dist: {
+              src: 'css/*.css'
             }
         },
 
@@ -65,5 +77,5 @@ module.exports = function (grunt) {
     });
 
     grunt.registerTask('default', ['sass:dist', 'watch', 'uglify:dev']);
-    grunt.registerTask('prod', ['sass:prod', 'uglify:prod']);
+    grunt.registerTask('prod', ['sass:prod', 'uglify:prod', 'postcss']);
 };

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "grunt-contrib-uglify": "^0.9.2",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-notify": "^0.4.1",
+    "grunt-postcss": "^0.7.1",
     "grunt-sass": "^1.0.0",
     "load-grunt-tasks": "^3.3.0"
   }

--- a/sass/partials/_mixins.scss
+++ b/sass/partials/_mixins.scss
@@ -13,13 +13,6 @@
     }
 }
 
-// old school shiz
-@mixin image-transform($rotate-deg) {
-    -ms-transform: rotate($rotate-deg); /* IE 9 */
-    -webkit-transform: rotate($rotate-deg); /* Ch <36, Saf 5.1+, iOS, An =<4.4.4 */
-    transform: rotate($rotate-deg); /* IE 10, Fx 16+, Op 12.1+ */
-}
-
 // mixin to color all team member sections.
 @mixin team-color-scheme($color) {
     background-color: $color;

--- a/sass/partials/modules/_about.scss
+++ b/sass/partials/modules/_about.scss
@@ -134,13 +134,13 @@
         }
 
         &.right {
-            @include image-transform(5deg);
+            transform: rotate(5deg);
             left: -60px;
             z-index: 0;
         }
         
         &.left {
-            @include image-transform(-5deg);
+            transform: rotate(-5deg);
             left: 60px;
             z-index: 0;
         }

--- a/sass/partials/modules/_gallery.scss
+++ b/sass/partials/modules/_gallery.scss
@@ -1,183 +1,183 @@
 // Gallery Mobile
 .section-gallery h2 {
-	@media (min-width: 768px) {
-		display: none;
-	}
+    @media (min-width: 768px) {
+        display: none;
+    }
 }
 
 .section-gallery img {
-	@media only screen and (max-width: 768px) {
-		height: auto;
-		max-width: 100%;
-	}
+    @media only screen and (max-width: 768px) {
+        height: auto;
+        max-width: 100%;
+    }
 }
 
 .section-gallery {
-	width: 100%;
+    width: 100%;
   @media (min-width: 768px) {
-		padding: 60px 30px;
+        padding: 60px 30px;
   }
-	@media (min-width: 1280px) {
-		padding: 60px;
-	}
+    @media (min-width: 1280px) {
+        padding: 60px;
+    }
 }
 
 .gallery-imgs {
-	width: 100%;
+    width: 100%;
 
-	@media (min-width: 768px) {
-		list-style: none;
-		text-align: center;
-	}
+    @media (min-width: 768px) {
+        list-style: none;
+        text-align: center;
+    }
 }
 
 .slider-content {
-	@media only screen and (max-width: 768px) {
-		display: none;
-		width: 100%;
-	}
+    @media only screen and (max-width: 768px) {
+        display: none;
+        width: 100%;
+    }
 }
 
 .first-pic {
-	@media only screen and (max-width: 768px) {
-		display: block;
-	}
+    @media only screen and (max-width: 768px) {
+        display: block;
+    }
 }
 
 .slider-image {
-	@media only screen and (max-width: 768px) {
-		height: 610px;
-		width: 100%;
-	}
+    @media only screen and (max-width: 768px) {
+        height: 610px;
+        width: 100%;
+    }
 }
 
 .counter-slider {
   text-align: center;
   width: 100%;
-	@media (min-width: 768px) {
-		display: none;
-	}
+    @media (min-width: 768px) {
+        display: none;
+    }
 }
 
 .gallery-container {
   width: 100%;
   @media (min-width: 1280px) {
-	font-size: 0; /* Hack that removes white space */
-	list-style: none;
-	margin: 0 auto;
-	width: 80%;
+    font-size: 0; /* Hack that removes white space */
+    list-style: none;
+    margin: 0 auto;
+    width: 80%;
   }
 }
 
 // Gallery Desktop
 @media (min-width: 768px) {
-	.gallery-imgs li {
-		background: url(../img/polaroid.jpg);
-		box-shadow: 0 5px 4px 0 rgba(0, 0, 0, .4);
-		display: inline-block;
-		padding: 10px 10px 40px;
-		vertical-align: top;
-		width: 33%;
+    .gallery-imgs li {
+        background: url(../img/polaroid.jpg);
+        box-shadow: 0 5px 4px 0 rgba(0, 0, 0, .4);
+        display: inline-block;
+        padding: 10px 10px 40px;
+        vertical-align: top;
+        width: 33%;
 
-		@media (max-width: 1024px) {
-			padding: 5px 5px 25px;
-		}
-	}
+        @media (max-width: 1024px) {
+            padding: 5px 5px 25px;
+        }
+    }
 
-	.gallery-imgs li img {
-		height: auto;
-		max-width: 100%;
-	}
+    .gallery-imgs li img {
+        height: auto;
+        max-width: 100%;
+    }
 
-	// Scattered Pictures Style
-	.gallery-imgs .pic-1 {
-		@include image-transform(-10deg);
-	}
+    // Scattered Pictures Style
+    .gallery-imgs .pic-1 {
+        transform: rotate(-10deg);
+    }
 
-	.gallery-imgs .pic-2 {
-		@include image-transform(10deg);
-		margin-top: 20px;
-	}
+    .gallery-imgs .pic-2 {
+        transform: rotate(10deg);
+        margin-top: 20px;
+    }
 
-	.gallery-imgs .pic-3 {
-		@include image-transform(-5deg);
-		left: 5px;
-		margin-top: -25px;
-		position: relative;
-	}
+    .gallery-imgs .pic-3 {
+        transform: rotate(-5deg);
+        left: 5px;
+        margin-top: -25px;
+        position: relative;
+    }
 
-	.gallery-imgs .pic-4 {
-		@include image-transform(-15deg);
-		margin-top: -10px;
-	}
+    .gallery-imgs .pic-4 {
+        transform: rotate(-15deg);
+        margin-top: -10px;
+    }
 
-	.gallery-imgs .pic-5 {
-		@include image-transform(-5deg);
-		position: relative;
-		right: 15px;
-	}
+    .gallery-imgs .pic-5 {
+        transform: rotate(-5deg);
+        position: relative;
+        right: 15px;
+    }
 
-	.gallery-imgs .pic-6 {
-		@include image-transform(10deg);
-		left: 5px;
-		position: relative;
-		margin-top: -22px;
-	}
+    .gallery-imgs .pic-6 {
+        transform: rotate(10deg);
+        left: 5px;
+        position: relative;
+        margin-top: -22px;
+    }
 
-	.gallery-imgs .pic-7 {
-		@include image-transform(5deg);
-		margin-top: -40px;
-	}
+    .gallery-imgs .pic-7 {
+        transform: rotate(5deg);
+        margin-top: -40px;
+    }
 
-	.gallery-imgs .pic-8 {
-		@include image-transform(-10deg);
-		margin-top: 25px;
-	}
+    .gallery-imgs .pic-8 {
+        transform: rotate(-10deg);
+        margin-top: 25px;
+    }
 
-	.gallery-imgs .pic-9 {
-		@include image-transform(15deg);
-		margin-top: -60px;
-	}
+    .gallery-imgs .pic-9 {
+        transform: rotate(15deg);
+        margin-top: -60px;
+    }
 
-	// Gallery-Modal Desktop
-	.modal {
-		background-color: rgba(0, 0, 0, .9);
-		display: block;
-		height: 100%;
-		left: 0;
-		padding: 5% 0;
-		position: fixed;
-		text-align: center;
-		top: 0;
-		width: 100%;
-		z-index: 999;
+    // Gallery-Modal Desktop
+    .modal {
+        background-color: rgba(0, 0, 0, .9);
+        display: block;
+        height: 100%;
+        left: 0;
+        padding: 5% 0;
+        position: fixed;
+        text-align: center;
+        top: 0;
+        width: 100%;
+        z-index: 999;
 
-		.exit {
-			cursor: pointer;
-			position: absolute;
-			right: 2%;
-			top: 5%;
-			width: 40px;
-		}
+        .exit {
+            cursor: pointer;
+            position: absolute;
+            right: 2%;
+            top: 5%;
+            width: 40px;
+        }
 
-		.full-picture {
-			height: 100%;
-			max-width: 80%;
-			text-align: center;
-		}
+        .full-picture {
+            height: 100%;
+            max-width: 80%;
+            text-align: center;
+        }
 
-		.next {
-			cursor: pointer;
-			position: absolute;
-			right: 2%;
-			top: 50%;
-		}
+        .next {
+            cursor: pointer;
+            position: absolute;
+            right: 2%;
+            top: 50%;
+        }
 
-		.previous {
-			cursor: pointer;
-			left: 2%;
-			position: absolute;
-			top: 50%;
-		}
-	}
+        .previous {
+            cursor: pointer;
+            left: 2%;
+            position: absolute;
+            top: 50%;
+        }
+    }
 }

--- a/sass/partials/modules/_language-block.scss
+++ b/sass/partials/modules/_language-block.scss
@@ -1,108 +1,106 @@
 .content-lang {
-	margin-top: 4%;
-	position: absolute;
-	right: 18%;
-	@media(min-width: 768px){
-		float: right;
-		margin: 3% 4% 0 0;
-		position: inherit;
-	}
+    margin-top: 4%;
+    position: absolute;
+    right: 18%;
+    
+    @media(min-width: 768px){
+        float: right;
+        margin: 3% 4% 0 0;
+        position: inherit;
+    }
 }
 
 .close-lang {
-	background: rgba(0, 0, 0, .4);
-	border: 3px solid $main-color;
-	cursor: pointer;
-	height: 41px;
-	position: absolute;
-	padding: 2px 5px;
-	width: 41px;
+    background: rgba(0, 0, 0, .4);
+    border: 3px solid $main-color;
+    cursor: pointer;
+    height: 41px;
+    position: absolute;
+    padding: 2px 5px;
+    width: 41px;
 
-	@media(min-width: 768px) {
-		display: none;
-	}
+    @media(min-width: 768px) {
+        display: none;
+    }
 }
 
 .list-lang {
-	list-style: none;
-	position: absolute;
-	z-index: 1;
+    list-style: none;
+    position: absolute;
+    z-index: 1;
 
-	@media(min-width: 768px){
-		position: inherit;
-	}
+    @media(min-width: 768px){
+        position: inherit;
+    }
 }
 
 .list-lang-item {
-	border: 3px solid $main-color;
-	cursor: pointer;
-	left: 0;
-	padding: 8px;
-	position: absolute;
-	text-align: center;
-	top: -11px;
-	-moz-transition: all 1s;
-	-o-transition: all 1s;
-	-webkit-transition: all 1s;
-	transition: all 1s;
+    border: 3px solid $main-color;
+    cursor: pointer;
+    left: 0;
+    padding: 8px;
+    position: absolute;
+    text-align: center;
+    top: -11px;
+    transition: all 1s;
 
-	@media(min-width: 768px){
-		display:inline-block;
-		position: inherit;
-	}
-	
-	&.selected {
-		background: #24C29F;
-		z-index: 3;
-		
-		a {
-			color: #fff;
-			text-shadow: 1px 1px 4px $light-color;
-		}
-	}
+    @media(min-width: 768px){
+        display:inline-block;
+        position: inherit;
+    }
+    
+    &.selected {
+        background: #24C29F;
+        z-index: 3;
+        
+        a {
+            color: #fff;
+            text-shadow: 1px 1px 4px $light-color;
+        }
+    }
 }
 
 .list-lang-item a {
-	@include font-size(18);
-	color: #24C29F;
-	font-family: $text-serif;
-	text-decoration: none;
-	text-shadow: 1px 1px 4px $main-color;
-	text-transform: uppercase;
+    @include font-size(18);
+    color: #24C29F;
+    font-family: $text-serif;
+    text-decoration: none;
+    text-shadow: 1px 1px 4px $main-color;
+    text-transform: uppercase;
 }
 
 .list-lang li:first-child + li {
-	@include image-transform(10deg);
+    transform: rotate(10deg);
 
-	@media(min-width: 768px) {
-		@include image-transform(0deg);
-	}
+    @media(min-width: 768px) {
+        transform: rotate(0deg);
+    }
 }
 
 .list-lang li:last-child {
-	@include image-transform(10deg);
+    transform: rotate(10deg);
 
-	@media(min-width: 768px) {
-		@include image-transform(0deg);
-	}
+    @media(min-width: 768px) {
+        transform: rotate(0deg);
+    }
 }
 
 .lang-item-position-0 { // estas clases donde se usan?
-	top: 55px;
+    top: 55px;
 }
 
 .lang-item-position-1 {
-	top: 110px;
+    top: 110px;
 }
 
 .lang-item-position-2 {
-	top: 165px;
+    top: 165px;
 }
 
 .lang-item-position-3 {
-	top: 220px;
+    top: 220px;
 }
 
 .lang-item-position-4 {
-	top: 220px;
+    top: 220px;
 }

--- a/sass/partials/modules/_team.scss
+++ b/sass/partials/modules/_team.scss
@@ -52,7 +52,7 @@
         font-family: $text-sans;
     }
 
-    a{
+    a {
         @include font-size ($links-size);
         text-decoration: underline;
         &:hover{
@@ -60,7 +60,7 @@
         }
     }
 
-    @media(min-width: 1024px){
+    @media(min-width: 1024px) {
         height: 640px;
         width: 50%;
     }


### PR DESCRIPTION
Cuando hagan el merge, corran en terminal
`npm install grunt-postcss autoprefixer`

Con este cambio, ya no hay que usar prefixes en las propiedades de CSS, cuando se corra el task, los prefixes se agregan directo en el CSS compilado solo cuando sea necesario, estamos soportando las ultimas tres versiones de browsers para no dejar mamando a IE9

https://github.com/nDmitry/grunt-postcss
